### PR TITLE
Upgrading References for PSC Version 0.7.6.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,13 +15,16 @@
   "dependencies": {
     "purescript-lists": "~0.7.0",
     "purescript-sequences": "~0.4.1",
-    "purescript-strings": "~0.5.3",
+    "purescript-strings": "~0.7.1",
     "purescript-functions": "~0.1.0"
   },
   "devDependencies": {
     "purescript-console": "~0.1.0",
     "purescript-math": "~0.2.0",
     "purescript-simple-assert": "~0.3.0",
-    "purescript-strongcheck": "~0.10.0"
+    "purescript-strongcheck": "~0.14.7"
+  },
+  "resolutions": {
+    "purescript-strings": "~0.7.1"
   }
 }


### PR DESCRIPTION
In the current version, I get an error when compiling with psc 0.7.6.1, stating that there are "orphan instances" in module Data.Char, which is part of package purescript-strings.

Upgrading to the newest version of this package (and the package purescript-strongcheck) seems to fix the problem.
